### PR TITLE
feat(add): brightness control

### DIFF
--- a/config.h
+++ b/config.h
@@ -133,6 +133,11 @@ static Key keys[] = {
 	{ 0, XF86XK_AudioPlay, spawn, {.v = medplaypausecmd } },
 	{ 0, XF86XK_AudioNext, spawn, {.v = mednextcmd } },
 	{ 0, XF86XK_AudioPrev, spawn, {.v = medprevcmd } },
+	//Keybindings for Brightness control
+	{ 0, XF86XK_MonBrightnessUp, spawn, {.v = (const char*[]){ "xbacklight", "-inc", "5", NULL } } },
+	{ 0, XF86XK_MonBrightnessDown, spawn, {.v = (const char*[]){ "xbacklight", "-dec", "5", NULL } } },
+
+	
 
 	TAGKEYS(                        XK_1,                      0)
 	TAGKEYS(                        XK_2,                      1)


### PR DESCRIPTION
Brightness control was added to my X1 setup, i used `xbacklight` and `XF85XK` for keeping it simple and standardized.